### PR TITLE
Rebuild to fix ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
As cryptpp uses static linking we need to rebuild for https://github.com/conda-forge/cryptopp-feedstock/pull/36